### PR TITLE
refactor: adapt to new history API specification

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,7 @@
   width: 100%;
   min-height: 100vh;
   display: flex;
-  justify-content: center;  /* 가로 중앙 정렬 */
-  align-items: center;      /* 세로 중앙 정렬 */
+  justify-content: center; /* 가로 중앙 정렬 */
+  align-items: center; /* 세로 중앙 정렬 */
   background-color: white;
 }

--- a/src/api/history.ts
+++ b/src/api/history.ts
@@ -3,11 +3,14 @@ import { ApiResponse, WidgetData } from '@/types';
 
 // const API_URL = import.meta.env.VITE_API_URL;  // 환경변수는 제거
 
-export const fetchHistory = async (deviceId: string = import.meta.env.VITE_DEVICE_ID): Promise<ApiResponse<WidgetData>> => {
+export const fetchHistory = async (
+  deviceId: string = import.meta.env.VITE_DEVICE_ID
+): Promise<ApiResponse<WidgetData>> => {
   try {
-    // ${API_URL} 대신 proxy 경로인 /api 사용  
-    const response = await axios.get<ApiResponse<WidgetData>>(`api/widget/${deviceId}`);
-    console.log(response.data);
+    // ${API_URL} 대신 proxy 경로인 /api 사용
+    const response = await axios.get<ApiResponse<WidgetData>>(
+      `api/widget/${deviceId}`
+    );
     return response.data;
   } catch (error) {
     console.error('History fetch error:', error);

--- a/src/components/TryOnWidget/History.tsx
+++ b/src/components/TryOnWidget/History.tsx
@@ -1,36 +1,23 @@
 import React from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { currentModelState, historyState } from '@/recoil/atoms';
-import { HistoryContainer, HistoryWrapper, HistoryTitle } from '@styles/TryOnWidget';
+import {
+  HistoryContainer,
+  HistoryWrapper,
+  HistoryTitle,
+} from '@styles/TryOnWidget';
 import HistoryItem from './HistoryItem';
 
 const History: React.FC = () => {
   const [currentModel, setCurrentModel] = useRecoilState(currentModelState);
-  const [history, setHistory] = useRecoilState(historyState);
-  
-  // 현재 모델 업데이트 함수
-  const updateCurrentModel = (newImageUrl: string) => {
-    // 현재 모델의 이미지만 업데이트
-    const updatedModel = {
-      ...currentModel,
-      itemImageUrl: newImageUrl
-    };
-    
-    // 현재 모델 상태 업데이트
-    setCurrentModel(updatedModel);
-    
-    // 히스토리에서도 해당 모델 업데이트
-    const updatedHistory = history.map(item => 
-      item.id === currentModel.id ? updatedModel : item
-    );
-    setHistory(updatedHistory);
-  };
+  const history = useRecoilValue(historyState);
 
   const emptyBoxes = Array(6).fill(null);
-  const latestHistory = history.slice(0,6);
-  const items = history.length > 0 
-    ? [...latestHistory, ...emptyBoxes].slice(0, 6)
-    : emptyBoxes;
+  const latestHistory = history.slice(0, 6);
+  const items =
+    history.length > 0
+      ? [...latestHistory, ...emptyBoxes].slice(0, 6)
+      : emptyBoxes;
 
   return (
     <HistoryWrapper>
@@ -38,10 +25,10 @@ const History: React.FC = () => {
       <HistoryContainer>
         {items.map((item, index) => (
           <HistoryItem
-            key={item?.id || index}
+            key={`history-item-${index}`}
             item={item}
             onClick={setCurrentModel}
-            isActive={item?.id === currentModel.id}  // 현재 선택된 모델 표시
+            isActive={item?.id === currentModel.id} // 현재 선택된 모델 표시
           />
         ))}
       </HistoryContainer>

--- a/src/components/TryOnWidget/HistoryItem.tsx
+++ b/src/components/TryOnWidget/HistoryItem.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { ModelItem } from '@/types/model';  // 경로 수정
-import { StyledHistoryImage, EmptyHistoryItem, HistoryItemWrapper } from '@styles/TryOnWidget';
+import { ModelItem } from '@/types/model'; // 경로 수정
+import {
+  StyledHistoryImage,
+  EmptyHistoryItem,
+  HistoryItemWrapper,
+} from '@styles/TryOnWidget';
 
 interface HistoryItemProps {
   item?: ModelItem;
@@ -8,7 +12,11 @@ interface HistoryItemProps {
   isActive?: boolean;
 }
 
-const HistoryItem: React.FC<HistoryItemProps> = ({ item, onClick, isActive }) => {
+const HistoryItem: React.FC<HistoryItemProps> = ({
+  item,
+  onClick,
+  isActive,
+}) => {
   if (!item) {
     return (
       <HistoryItemWrapper>
@@ -19,14 +27,9 @@ const HistoryItem: React.FC<HistoryItemProps> = ({ item, onClick, isActive }) =>
 
   return (
     <HistoryItemWrapper onClick={() => onClick?.(item)}>
-      <StyledHistoryImage
-        src={item.itemImageUrl}
-        $isActive={isActive}
-      />
+      <StyledHistoryImage src={item.modelImageUrl} $isActive={isActive} />
     </HistoryItemWrapper>
   );
 };
 
 export default HistoryItem;
-
-

--- a/src/components/TryOnWidget/ModelSelector.tsx
+++ b/src/components/TryOnWidget/ModelSelector.tsx
@@ -1,8 +1,8 @@
-import React, { useRef } from 'react';  // useRef 추가
+import React, { useRef } from 'react'; // useRef 추가
 import { useRecoilState } from 'recoil';
 import { historyState, currentModelState } from '@/recoil/atoms';
-import { requestAddModel } from '@/api/model';  // API 함수 import
-import FileUpload from './FileUpload';  // FileUpload 컴포넌트 import
+import { requestAddModel } from '@/api/model'; // API 함수 import
+import FileUpload from './FileUpload'; // FileUpload 컴포넌트 import
 import {
   SelectorContainer,
   SelectorButton,
@@ -26,17 +26,25 @@ const ModelSelector: React.FC = () => {
       }
 
       // 로컬 이미지 URL 사용
-      const imageUrl = modelType === 'male' 
-        ? '/images/models/default-male.png'
-        : '/images/models/default-female.png';
-      
+      const imageUrl =
+        modelType === 'male'
+          ? '/images/models/default-male.png'
+          : '/images/models/default-female.png';
+
       // 먼저 UI 업데이트
       const newModel = {
         id: Date.now(),
-        itemImageUrl: imageUrl,
         modelImageUrl: imageUrl,
+        fittings: [
+          {
+            // fittings 배열 추가
+            fittingId: Date.now(),
+            fittingImageUrl: '',
+            itemImageUrl: imageUrl,
+          },
+        ],
       };
-      
+
       setHistory([newModel, ...history]);
       setCurrentModel(newModel);
       setIsOpen(false);
@@ -46,10 +54,7 @@ const ModelSelector: React.FC = () => {
       const blob = await response.blob();
       const modelImage = new File([blob], 'model.png', { type: 'image/png' });
 
-      await requestAddModel(
-        import.meta.env.VITE_DEVICE_ID,
-        modelImage
-      );
+      await requestAddModel(import.meta.env.VITE_DEVICE_ID, modelImage);
     } catch (error) {
       console.error('Failed to add model:', error);
     }
@@ -66,8 +71,8 @@ const ModelSelector: React.FC = () => {
       if (response.success) {
         const newModel = {
           id: Date.now(),
-          itemImageUrl: response.result.modelUrl,    // 서버 응답 URL 사용
-          modelImageUrl: response.result.modelUrl,   // 서버 응답 URL 사용
+          itemImageUrl: response.result.modelUrl, // 서버 응답 URL 사용
+          modelImageUrl: response.result.modelUrl, // 서버 응답 URL 사용
         };
 
         setHistory([newModel, ...history]);

--- a/src/components/TryOnWidget/index.tsx
+++ b/src/components/TryOnWidget/index.tsx
@@ -32,8 +32,13 @@ const TryOnWidget: React.FC = () => {
 
         const modelItems = response.result.models.map((model) => ({
           id: model.modelId,
-          itemImageUrl: model.itemImageUrl,
+          itemImageUrl: model.fittings[0]?.itemImageUrl || '', // 첫 번째 fitting의 itemImageUrl
           modelImageUrl: model.modelImageUrl,
+          fittings: model.fittings.map((fitting) => ({
+            fittingId: fitting.fittingId,
+            fittingImageUrl: fitting.fittingImageUrl,
+            itemImageUrl: fitting.itemImageUrl,
+          })),
         }));
 
         setHistory(modelItems);
@@ -45,11 +50,18 @@ const TryOnWidget: React.FC = () => {
           // 선택된 모델 타입에 따라 기본 모델 설정
           setCurrentModel({
             id: 0,
-            itemImageUrl: '',
             modelImageUrl:
               selectedModel === 'male'
                 ? '/images/models/default-male.png'
                 : '/images/models/default-female.png',
+            fittings: [
+              {
+                // 기본 fitting 추가
+                fittingId: 0,
+                fittingImageUrl: '',
+                itemImageUrl: '',
+              },
+            ],
           });
         }
       } catch (error) {
@@ -57,11 +69,17 @@ const TryOnWidget: React.FC = () => {
         // 에러 발생시에도 기본 모델 설정
         setCurrentModel({
           id: 0,
-          itemImageUrl: '',
           modelImageUrl:
             selectedModel === 'male'
               ? '/images/models/default-male.png'
               : '/images/models/default-female.png',
+          fittings: [
+            {
+              fittingId: 0,
+              fittingImageUrl: '',
+              itemImageUrl: '',
+            },
+          ],
         });
       }
     };

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -5,16 +5,22 @@ import { ModelItem, ModelType } from '../types';
 export const currentModelState = atom<ModelItem>({
   key: 'currentModelState',
   default: {
-    id: 0,  // 기본값은 0으로 설정
-    itemImageUrl: '',  // 아이템 이미지는 없음
+    id: 0,
     modelImageUrl: '/images/models/default-male.png', // 기본 남성 모델
-  }
+    fittings: [
+      {
+        fittingId: 0,
+        fittingImageUrl: '',
+        itemImageUrl: '',
+      },
+    ],
+  },
 });
 
 // 히스토리 상태
 export const historyState = atom<ModelItem[]>({
   key: 'historyState',
-  default: []  // 빈 배열로 초기화
+  default: [], // 빈 배열로 초기화
 });
 
 // 나머지 상태들은 그대로 유지
@@ -22,16 +28,16 @@ export const modelListState = atom<ModelType[]>({
   key: 'modelListState',
   default: [
     { id: 'male', name: '남자 모델', type: 'default' },
-    { id: 'female', name: '여자 모델', type: 'default' }
-  ]
+    { id: 'female', name: '여자 모델', type: 'default' },
+  ],
 });
 
 export const selectedModelState = atom({
   key: 'selectedModelState',
-  default: 'male'
+  default: 'male',
 });
 
 export const isSelectorOpenState = atom({
   key: 'isSelectorOpenState',
-  default: false
+  default: false,
 });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,20 +1,26 @@
 export interface ApiResponse<T> {
-    success: boolean;
-    code: string;
-    message: string;
-    result: T;
-  }
-  
-  export interface WidgetData {
-    models: WidgetModel[];
-  }
-  
-  export interface WidgetModel {
-    modelId: number;
-    itemImageUrl: string;
-    modelImageUrl: string;
-  }
+  success: boolean;
+  code: string;
+  message: string;
+  result: T;
+}
 
-  export interface TryOnResult {
-    resultImageUrl: string;
+export interface WidgetData {
+  models: WidgetModel[];
+}
+
+export interface WidgetModel {
+  modelId: number;
+  modelImageUrl: string;
+  fittings: Fitting[];
+}
+
+export interface Fitting {
+  fittingId: number;
+  fittingImageUrl: string;
+  itemImageUrl: string;
+}
+
+export interface TryOnResult {
+  resultImageUrl: string;
 }


### PR DESCRIPTION
## Changes
- Update `ModelItem` type to include `fittings` array
- Modify history data mapping to match new API response structure
- Update default model state structure
- Fix key warnings in History component

## Details
### API Response Structure Changes
`typescript
{
models: [
{
modelId: number,
modelImageUrl: string,
fittings: [
{
fittingId: number,
fittingImageUrl: string,
itemImageUrl: string
}
]
}
]
}`

### Modified Components
- `TryOnWidget/index.tsx`: Update history data mapping
- `ModelSelector.tsx`: Adjust model creation structure
- `History.tsx`: Fix duplicate key warnings
- `types/api.ts`: Update type definitions

## Testing
- [x] History loads correctly with new API structure
- [x] Model selection works as expected
- [x] No TypeScript errors